### PR TITLE
Fix script/solution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    # Set up the environment
     - uses: actions/checkout@v2
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
@@ -14,4 +15,12 @@ jobs:
         python-version: 3.8
     - run: python -m pip install --upgrade pip
     - run: pip install -r requirements.txt
+
+    # Make sure we haven't broken any scripts
+    - name: Smoke test dev-env
+      run: |
+        source dev-env.sh
+        script/solution 1
+
+    # Run regression tests
     - run: pytest

--- a/dev-env.sh
+++ b/dev-env.sh
@@ -13,7 +13,7 @@ fi
 source "$venv_dir/bin/activate"
 
 export PROJECT_ROOT="$scriptdir"
-export PYTHONPATH="$PROJECT_ROOT"
+export PYTHONPATH="$PROJECT_ROOT/src"
 export MYPYPATH="$PYTHONPATH"
 export PYLINTRC="$PROJECT_ROOT/pylintrc"
 


### PR DESCRIPTION
After moving `mathtools` into the project, `script/solution` stopped working for most problems with the error:

```
No module named 'mathtools'
```

This was actually an existing bug with the dynamic import that would happen for any solution file that tried to import `core` (ex. the solution for Problem 11).